### PR TITLE
Fixed current map usage and fix undraft on enemy flee

### DIFF
--- a/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/AI/JobDriver_DeconstructBuilding.cs
+++ b/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/AI/JobDriver_DeconstructBuilding.cs
@@ -30,7 +30,7 @@ namespace VanillaMemesExpanded
 						ThingDef buildingToPopUp = comp.Props.defToPopUpMinified;
 						Thing thing = ThingMaker.MakeThing(buildingToPopUp, null);
 						thing = MinifyUtility.MakeMinified(thing);
-						GenPlace.TryPlaceThing(thing, building.Position, Find.CurrentMap, ThingPlaceMode.Direct, null, null, default(Rot4));
+						GenPlace.TryPlaceThing(thing, building.Position, building.Map, ThingPlaceMode.Direct, null, null, default(Rot4));
 
 					}
 					building.Destroy(DestroyMode.Vanish);

--- a/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Abilities/CompAbilityThrowParty.cs
+++ b/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Abilities/CompAbilityThrowParty.cs
@@ -17,7 +17,7 @@ namespace VanillaMemesExpanded
 		public override void Apply(LocalTargetInfo target, LocalTargetInfo dest)
 		{
 			
-			if (!Find.CurrentMap.lordsStarter.TryStartRandomGathering(true))
+			if (!parent.pawn.Map.lordsStarter.TryStartRandomGathering(true))
 			{
 				Messages.Message("VME_NoValidPartySpot".Translate(), MessageTypeDefOf.RejectInput, false);
 			}

--- a/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/LordToil_PanicFlee_Init.cs
+++ b/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/LordToil_PanicFlee_Init.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using Verse.AI;
-
+using Verse.AI.Group;
 
 
 namespace VanillaMemesExpanded
@@ -18,12 +18,13 @@ namespace VanillaMemesExpanded
     public static class VanillaMemesExpanded_LordToil_PanicFlee_Init_Patch
     {
         [HarmonyPostfix]
-        static void UndraftWhenEnemyFlees()
+        static void UndraftWhenEnemyFlees(Lord ___lord)
         {
 
             if (Current.Game.World.factionManager.OfPlayer.ideos.GetPrecept(InternalDefOf.VME_Violence_Abhorrent) != null)
-            { 
-                foreach(Pawn pawn in Find.CurrentMap.mapPawns.FreeColonistsAndPrisoners)
+            {
+                // Create a new list as otherwise we'll be met with `Collection was modified; enumeration operation may not execute.`
+                foreach(Pawn pawn in new List<Pawn>(___lord.Map.mapPawns.FreeColonistsAndPrisoners))
                 {
                     if (pawn.drafter?.Drafted == true && pawn.Ideo?.HasPrecept(InternalDefOf.VME_Violence_Abhorrent)==true)
                     {

--- a/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/MapComponents and GameComponents/MapComponent_MechanoidRaidFleeing.cs
+++ b/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/MapComponents and GameComponents/MapComponent_MechanoidRaidFleeing.cs
@@ -51,7 +51,7 @@ namespace VanillaMemesExpanded
                     if (numberOfEffigies >= PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_Colonists.Count*2)
                     {
                       
-                        foreach (Lord lord in Find.CurrentMap.lordManager.lords)
+                        foreach (Lord lord in map.lordManager.lords)
                         {
                             
                             if (lord.faction == Faction.OfMechanoids)

--- a/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Rituals/Outcomes/RitualOutcomeEffectWorker_InsectoidHymn.cs
+++ b/1.4/Source/VanillaMemesExpanded/VanillaMemesExpanded/Rituals/Outcomes/RitualOutcomeEffectWorker_InsectoidHymn.cs
@@ -60,7 +60,7 @@ namespace VanillaMemesExpanded
 
             if (outcome.positivityIndex == 2)
             {
-				foreach (Lord lord in Find.CurrentMap.lordManager.lords)
+				foreach (Lord lord in jobRitual.Map.lordManager.lords)
 				{
 
 					if (lord.faction == Faction.OfInsects)


### PR DESCRIPTION
Fixed the usage of `Find.CurrentMap` where it would cause bugs. For example:
- Auto undrafting of pacifist pawns happened on the current player map, not the one where enemies were fleeing.
- Trying to uninstall junk would place it minified on the map the player was on, not the one it was uninstalled on.

On top of that, a bug with undrafting the pacifist pawns. It would cause an error after undrafting the first pawn and stop iteration - "Collection was modified; enumeration operation may not execute."