### PR TITLE
Only add CompProperties_Styleable to defs without it

### DIFF
--- a/1.4/Patches/ArmchairPatch.xml
+++ b/1.4/Patches/ArmchairPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Armchair"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Armchair"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Armchair"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Armchair"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Armchair"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Armchair"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/DresserPatch.xml
+++ b/1.4/Patches/DresserPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Dresser"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Dresser"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Dresser"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/EndTablePatch.xml
+++ b/1.4/Patches/EndTablePatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "EndTable"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "EndTable"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "EndTable"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 


### PR DESCRIPTION
This should help with compatibility with mods that do that as well - if another mod added it before this one, it'll skip adding it (and prevent errors on game load).

This PR basically surrounds the patch operations adding the `CompProperties_Styleable` with another one that checks if the thing contains it first, and only adds it if it fails.

Recently, there was an issue with `ATH's style drakonic`, as both added the styleable comp to armchairs. This caused the following errors for each armchair placed on the map (2 errors per armchair placed):
`Tried to register the same load ID twice: null, pathRelToParent=/sourcePrecept, parent=Armchair14080`
`Could not get load ID. We're asking for something which was never added during LoadingVars. pathRelToParent=/sourcePrecept, parent=Armchair14080`

As far as I'm aware, `ATH's style drakonic` was patched so it only adds the comp if it's not there yet. However, if it's loaded before this one it'll still cause issues, as this mod is (at the moment) still adding the comp without checking for its presence.