### PR TITLE
Fishing Forbidden precept - add fishing skill as opposed

### DIFF
--- a/1.4/Mods/VanillaFishingExpanded/Defs/PreceptDefs/Precepts_Fishing.xml
+++ b/1.4/Mods/VanillaFishingExpanded/Defs/PreceptDefs/Precepts_Fishing.xml
@@ -47,6 +47,9 @@
 			</li>
 			
 		</comps>
+		<opposedWorkTypes>
+			<li>VCEF_Fishing</li>
+		</opposedWorkTypes>
 		
 	</PreceptDef>
 	


### PR DESCRIPTION
Added fishing skill as opposed for "fishing: forbidden" precept.

This doesn't have any gameplay effect, and the only purpose for this is to give the player a warning by giving the priority box an orange border, giving a warning message when assigning a pawn to that work type, as well as giving additional info in a tooltip when hovering over such a work type. (The only vanilla method this is used by is `RimWorld.Ideo.IsWorkTypeConsideredDangerous`.)

Before:
![FishingBefore](https://github.com/Vanilla-Expanded/VanillaIdeologyExpanded-Memes/assets/36712560/8201305a-bb9d-46a1-a612-4c0b34c40315)

After:
![FishingAfter](https://github.com/Vanilla-Expanded/VanillaIdeologyExpanded-Memes/assets/36712560/ed1ee56d-dd4e-4c85-92e4-2c8d81166e5b)