### PR TITLE
Fix bug with the Nomad debuff from the first base does not subside.

### DIFF
--- a/1.5/Source/VanillaMemesExpanded/VanillaMemesExpanded/MapComponents and GameComponents/GameComponent_TravellingAndTradingTracker.cs
+++ b/1.5/Source/VanillaMemesExpanded/VanillaMemesExpanded/MapComponents and GameComponents/GameComponent_TravellingAndTradingTracker.cs
@@ -80,6 +80,11 @@ namespace VanillaMemesExpanded
                             PawnCollectionClass.ticksWithoutAbandoning += tickInterval;
                         }
 
+                    } else {
+                        if (PawnCollectionClass.ticksWithoutAbandoning - tickInterval > 0)
+                        {
+                            PawnCollectionClass.ticksWithoutAbandoning -= tickInterval;
+                        } 
                     }
 
                 }


### PR DESCRIPTION
I saw a message in the steam: "I tried to play through the Nomads, but the debuff from first base does not subside. Is that how it should be? So, I spent more than 15 days on one of the bases and now I have a debuff imposed on me until the end of the game?", the developer said to throw a bug report. It's easily fixed with this fix. It's just that when he's not on base, you need to reduce the timer. It turns out that when a player is on base, the timer increases, and when he travels, the counter will decrease. It turns out that the original idea of the mod will exist - the player will travel, and then build a base for a while, and then he will be able to travel again. In a word, to be a nomad. And at the moment, the player is generally prohibited from building bases because this will immediately impose a permanent debuff.