### PR TITLE
Add null check for otherPawn in ThoughtWorker_Precept_Royalty ShouldHaveThought

### DIFF
--- a/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/ThoughtWorkers/ThoughtWorker_Precept_Social/ThoughtWorker_Precept_Royalty.cs
+++ b/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/ThoughtWorkers/ThoughtWorker_Precept_Social/ThoughtWorker_Precept_Royalty.cs
@@ -9,7 +9,7 @@ namespace VanillaMemesExpanded
         protected override ThoughtState ShouldHaveThought(Pawn p, Pawn otherPawn)
         {
 
-            if (Faction.OfEmpire is null ||  otherPawn.royalty.AllTitlesForReading.Count == 0)
+            if (Faction.OfEmpire is null ||  otherPawn is null || otherPawn.royalty.AllTitlesForReading.Count == 0)
             {
                 return false;
             }

--- a/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/ThoughtWorkers/ThoughtWorker_Precept_Social/ThoughtWorker_Precept_Royalty.cs
+++ b/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/ThoughtWorkers/ThoughtWorker_Precept_Social/ThoughtWorker_Precept_Royalty.cs
@@ -9,7 +9,7 @@ namespace VanillaMemesExpanded
         protected override ThoughtState ShouldHaveThought(Pawn p, Pawn otherPawn)
         {
 
-            if (Faction.OfEmpire is null ||  otherPawn is null || otherPawn.royalty.AllTitlesForReading.Count == 0)
+            if (Faction.OfEmpire is null ||  otherPawn.royalty is null || otherPawn.royalty.AllTitlesForReading.Count == 0)
             {
                 return false;
             }


### PR DESCRIPTION
In a heavily modded savegame, I receive extremely frequent errors whenever a null sneaks into the relationship checking code here:

Exception while recalculating VME_Royalty_Exalted thought state for pawn Levin: System.NullReferenceException: Object reference not set to an instance of an object [Ref 1F3242AA]
  at VanillaMemesExpanded.ThoughtWorker_Precept_Royalty.ShouldHaveThought (Verse.Pawn p, Verse.Pawn otherPawn) [0x00040] in <3df7cd57d1784f0b9057ff65ee01d2c2>:0 
  at RimWorld.ThoughtWorker_Precept_Social.CurrentSocialStateInternal (Verse.Pawn p, Verse.Pawn otherPawn) [0x0006f] in <24d25868955f4df08b02c73b55f389fe>:0 


It seems safe to guard against this by quickly exiting the thought check if the otherPawn is invalid, just like the check for the empire faction itself.