### PR TITLE
Fix inconsistent craft quality notification

### DIFF
--- a/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/GenRecipe_PostProcessProduct.cs
+++ b/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/GenRecipe_PostProcessProduct.cs
@@ -1,11 +1,6 @@
 ﻿using HarmonyLib;
 using RimWorld;
-using System.Reflection;
 using Verse;
-using UnityEngine;
-using System.Collections.Generic;
-using System.Linq;
-using Verse.AI;
 
 namespace VanillaMemesExpanded
 {
@@ -13,47 +8,15 @@ namespace VanillaMemesExpanded
     [HarmonyPatch("PostProcessProduct")]
     public static class VanillaMemesExpanded_GenRecipe_PostProcessProduct_Patch
     {
-        [HarmonyPostfix]
-        static void IncreaseQualityByOne(Thing product, RecipeDef recipeDef, Pawn worker)
-        {         
-                if (worker?.Ideo?.HasPrecept(InternalDefOf.VME_CraftingQuality_Increased) == true)
+        public static void Postfix(Thing product, RecipeDef recipeDef, Pawn worker)
+        {
+            if (worker?.Ideo?.HasPrecept(InternalDefOf.VME_BookWriting_Exalted) == true)
+            {
+                if (product?.HasThingCategory(InternalDefOf.Books) == true && worker != null)
                 {
-                    CompQuality compQuality = product?.TryGetComp<CompQuality>();
-                    if (compQuality != null)
-                    {
-                        if (recipeDef?.workSkill == null)
-                        {
-                            Log.Error(recipeDef + " needs workSkill because it creates a product with a quality.");
-                        }
-                        if (compQuality.Quality != QualityCategory.Legendary)
-                        {
-                            compQuality.SetQuality(compQuality.Quality + 1, ArtGenerationContext.Colony);
-                        }
-                    }
-                }
-                if (worker?.Ideo?.HasPrecept(InternalDefOf.VME_CraftingQuality_Decreased) == true)
-                {
-                    CompQuality compQuality = product?.TryGetComp<CompQuality>();
-                    if (compQuality != null)
-                    {
-                        if (recipeDef?.workSkill == null)
-                        {
-                            Log.Error(recipeDef + " needs workSkill because it creates a product with a quality.");
-                        }
-                        if (compQuality.Quality != QualityCategory.Awful)
-                        {
-                            compQuality.SetQuality(compQuality.Quality - 1, ArtGenerationContext.Colony);
-                        }
-                    }
-                }
-
-                if (worker?.Ideo?.HasPrecept(InternalDefOf.VME_BookWriting_Exalted) == true)
-                {
-                    if (product?.HasThingCategory(InternalDefOf.Books) == true && worker != null)
-                    {
-                        Find.HistoryEventsManager.RecordEvent(new HistoryEvent(InternalDefOf.VME_WroteBook, worker.Named(HistoryEventArgsNames.Doer)), true);
-                    }
+                    Find.HistoryEventsManager.RecordEvent(new HistoryEvent(InternalDefOf.VME_WroteBook, worker.Named(HistoryEventArgsNames.Doer)), true);
                 }
             }
         }
+    }
 }

--- a/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/QualityUtility_GenerateQualityCreatedByPawn.cs
+++ b/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/Harmony/QualityUtility_GenerateQualityCreatedByPawn.cs
@@ -1,0 +1,28 @@
+using System;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace VanillaMemesExpanded
+{
+    [HarmonyPatch(typeof(QualityUtility), nameof(QualityUtility.GenerateQualityCreatedByPawn), [typeof(Pawn), typeof(SkillDef), typeof(bool)])]
+    public static class VanillaMemesExpanded_QualityUtility_GenerateQualityCreatedByPawn_Patch
+    {
+        public static void Postfix(Pawn pawn, SkillDef relevantSkill, ref QualityCategory __result)
+        {
+            if (relevantSkill != SkillDefOf.Construction)
+            {
+                var ideo = pawn?.Ideo;
+
+                if (ideo?.HasPrecept(InternalDefOf.VME_CraftingQuality_Increased) == true)
+                {
+                    __result = (QualityCategory)Math.Min((int)__result + 1, (int)QualityCategory.Legendary);
+                }
+                if (ideo?.HasPrecept(InternalDefOf.VME_CraftingQuality_Decreased) == true)
+                {
+                    __result = (QualityCategory)Math.Max((int)__result - 1, (int)QualityCategory.Awful);
+                }
+            }
+        }
+    }
+}

--- a/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/VanillaMemesExpanded.csproj
+++ b/1.6/Source/VanillaMemesExpanded/VanillaMemesExpanded/VanillaMemesExpanded.csproj
@@ -201,10 +201,6 @@
       <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
@@ -231,10 +227,6 @@
     </Reference>
     <Reference Include="UnityEngine.UmbraModule">
       <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UNETModule">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.UNETModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule">
@@ -379,6 +371,7 @@
     <Compile Include="Harmony\PawnRenderNodeWorker_Apparel_Head_HeadgearVisible.cs" />
     <Compile Include="Harmony\Pawn_RoyaltyTracker_OnPostTitleChanged.cs" />
     <Compile Include="Harmony\Pawn_RoyaltyTracker_TryRemoveFavor.cs" />
+    <Compile Include="Harmony\QualityUtility_GenerateQualityCreatedByPawn.cs" />
     <Compile Include="Harmony\RitualObligationTargetWorker_IdeoBuildingOrRitualSpot_CanUseTargetInternal.cs" />
     <Compile Include="Harmony\RoyalTitlePermitDef_CooldownTicks.cs" />
     <Compile Include="Harmony\RoyalTitlePermitWorker_FillAidOption_Patch.cs" />


### PR DESCRIPTION
This PR changes the patching location for the crafting quality precept, which fixes an issue that the quality notification does not match the corresponding produced item.

For example: currently, with crafting quality precept being increased, it is possible that the notification letter says a masterwork quality item has been produced, but the actual quality could be legendary. This PR fixes this inconsistency.

This PR also removes two invalid project references that do not exist any more.